### PR TITLE
Static field objects are now created on constructor.

### DIFF
--- a/source/Windows.Devices.Spi/SpiController.cs
+++ b/source/Windows.Devices.Spi/SpiController.cs
@@ -17,7 +17,7 @@ namespace Windows.Devices.Spi
         // this is used as the lock object 
         // a lock is required because multiple threads can access the SpiController
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly object _syncLock = new object();
+        private object _syncLock;
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly int _controllerId;
@@ -38,6 +38,11 @@ namespace Windows.Devices.Spi
             {
                 if (s_deviceCollection == null)
                 {
+                    if (_syncLock == null)
+                    {
+                        _syncLock = new object();
+                    }
+
                     lock (_syncLock)
                     {
                         if (s_deviceCollection == null)

--- a/source/Windows.Devices.Spi/SpiControllerManager.cs
+++ b/source/Windows.Devices.Spi/SpiControllerManager.cs
@@ -9,7 +9,7 @@ namespace Windows.Devices.Spi
 {
     internal sealed class SpiControllerManager
     {
-        private static readonly object _syncLock = new object();
+        private static object s_syncLock;
 
         // backing field for ControllersCollection
         // to store the controllers that are open
@@ -27,7 +27,12 @@ namespace Windows.Devices.Spi
             {
                 if (s_controllersCollection == null)
                 {
-                    lock (_syncLock)
+                    if (s_syncLock == null)
+                    {
+                        s_syncLock = new object();
+                    }
+
+                    lock (s_syncLock)
                     {
                         if (s_controllersCollection == null)
                         {

--- a/source/Windows.Devices.Spi/SpiDevice.cs
+++ b/source/Windows.Devices.Spi/SpiDevice.cs
@@ -21,7 +21,7 @@ namespace Windows.Devices.Spi
         // this is used as the lock object 
         // a lock is required because multiple threads can access the device
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly object _syncLock = new object();
+        private object _syncLock;
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly string _spiBus;
@@ -68,6 +68,8 @@ namespace Windows.Devices.Spi
 
                 // ... and add this device
                 controller.DeviceCollection.Add(deviceId, this);
+
+                _syncLock = new object();
             }
             else
             {


### PR DESCRIPTION
## Description
- Static field objects are now created on constructor.

## Motivation and Context
- Creating the static fields objects on the class constructor prevents issues related with using the class or their fields on other static constructor or reference because of the dependencies and the order things get initialized in the CLR.


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
