### PR TITLE
Protect ChipSelectLine value

### DIFF
--- a/Windows.Devices.Spi/Spi​Connection​Settings.cs
+++ b/Windows.Devices.Spi/Spi​Connection​Settings.cs
@@ -53,7 +53,7 @@ namespace Windows.Devices.Spi
         }
 
         /// <summary>
-        /// Gets or sets the chip select line for the connection to the SPI device.
+        /// Gets the chip select line for the connection to the SPI device.
         /// </summary>
         /// <value>
         /// The chip select line.
@@ -61,7 +61,6 @@ namespace Windows.Devices.Spi
         public int ChipSelectLine
         {
             get { return _csLine; }
-            set { _csLine = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ChipSelectLine is required by the constructor so the value should not be changed.

## Description
<!--- Describe your changes in detail -->
Protect ChipSelectLine value by removing set accessor from the property.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
